### PR TITLE
Issue #35. Running Gazebo headless and generating openCV images from simulator cameras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/simulator/descriptions/urab_sub_description/urdf/urab_sub_actuators.xacro
+++ b/simulator/descriptions/urab_sub_description/urdf/urab_sub_actuators.xacro
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2016 The UUV Simulator Authors.
      All rights reserved.
 
-     Contributed by Kristoffer Rakstad Solberg, 
+     Contributed by Kristoffer Rakstad Solberg,
      Student2019 Manta AUV, Vortex NTNU. -->
 
 
@@ -16,23 +16,23 @@
   <!-- Thruster joint and link snippet -->
 <!-- Time constant for thruster dynamics: rpm = K / (Ts + 1)
     <rotorConstant> T200, 12V for a 2nd order curve fit: tau = gain * abs(x)*x -->
-  <xacro:macro name="thruster_macro" 
+  <xacro:macro name="thruster_macro"
     params="namespace thruster_id *origin">
-    <!-- Macro definition here: 
+    <!-- Macro definition here:
     https://github.com/uuvsimulator/uuv_simulator/blob/5684de4827729f163f118cdc3a841011ef25ed8d/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/urdf/thruster_snippets.xacro#L135 -->
     <xacro:thruster_module_first_order_basic_fcn_macro
       namespace="${namespace}"
       thruster_id="${thruster_id}"
       mesh_filename="${prop_mesh_file_cw}"
-      dyn_time_constant="0.2"     
-      rotor_constant="0.000004">  
+      dyn_time_constant="0.2"
+      rotor_constant="0.000004">
       <xacro:insert_block name="origin"/>
     </xacro:thruster_module_first_order_basic_fcn_macro>
   </xacro:macro>
 
 <!-- Time constant for thruster dynamics: rpm = K / (Ts + 1)
     <rotorConstant> T200, 12V for a 2nd order curve fit: tau = gain * abs(x)*x -->
-  <xacro:macro name="thruster_macro_ccw" 
+  <xacro:macro name="thruster_macro_ccw"
     params="namespace thruster_id *origin">
     <xacro:thruster_module_first_order_basic_fcn_macro
       namespace="${namespace}"
@@ -47,36 +47,62 @@
 <!-- Thrusters probably advertise to these topics:
      https://github.com/uuvsimulator/uuv_simulator/blob/5684de4827729f163f118cdc3a841011ef25ed8d/uuv_gazebo_plugins/uuv_gazebo_ros_plugins/src/ThrusterROSPlugin.cc#L153-L168 -->
 
-<!-- Top thrusters --> 
+<!-- Top thrusters -->
 
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="0"> <!-- heave back left prop up-->
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="0">
   <origin xyz="-0.12070 0.12070 0" rpy="0 -1.5707963268 0"/>
   </xacro:thruster_macro>
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="1"> <!-- heave bacl right prop up-->
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="1">
     <origin xyz="-0.12070 -0.12070 0" rpy="0 -1.5707963268 0"/>
   </xacro:thruster_macro>
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="2"> <!-- heave front left prop up-->
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="2">
     <origin xyz="0.12070 0.12070 0" rpy="0 -1.5707963268 0"/>
   </xacro:thruster_macro>
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="3"> <!-- heave front right prop up-->
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="3">
     <origin xyz="0.12070 -0.12070 0" rpy="0 -1.5707963268 0"/>
   </xacro:thruster_macro>
 
+  <!-- <xacro:thruster_macro namespace="${namespace}" thruster_id="0">
+  <origin xyz="-0.143825 0.280455 0.230245" rpy="0 -1.5707963268 0"/>
+  </xacro:thruster_macro>
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="1">
+    <origin xyz="-0.143825 -0.280455 0.230245" rpy="0 -1.5707963268 0"/>
+  </xacro:thruster_macro>
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="2">
+    <origin xyz="0.143825 0.280455 0.230245" rpy="0 -1.5707963268 0"/>
+  </xacro:thruster_macro>
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="3">
+    <origin xyz="0.143825 -0.280455 0.230245" rpy="0 -1.5707963268 0"/>
+  </xacro:thruster_macro> -->
+
  <!-- Front thrusters -->
 
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="6"> <!-- lat front left-->
-    <origin xyz="0.20506 0.20506 0" rpy="${0*d2r} ${0*d2r} ${135*d2r}"/> 
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="6">
+    <origin xyz="0.20506 0.20506 0" rpy="${0*d2r} ${0*d2r} ${135*d2r}"/>
   </xacro:thruster_macro>
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="7"> <!-- lat front right -->
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="7">
     <origin xyz="0.20506 -0.20506 0" rpy="${0*d2r} ${0*d2r} ${-135*d2r}"/>
   </xacro:thruster_macro>
 
- <!-- Back thrusters -->
+  <!-- <xacro:thruster_macro namespace="${namespace}" thruster_id="6">
+    <origin xyz="0.192247 0.286933 0.0721539" rpy="${0*d2r} ${0*d2r} ${135*d2r}"/>
+  </xacro:thruster_macro>
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="7">
+    <origin xyz="0.192247 -0.286933 0.0721539" rpy="${0*d2r} ${0*d2r} ${-135*d2r}"/>
+  </xacro:thruster_macro> -->
 
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="4"> <!-- lat back left-->
-    <origin xyz="-0.20506 0.20506 0" rpy="${0*d2r} ${0*d2r} ${45*d2r}"/>
+ <!-- Back thrusters -->
+ <xacro:thruster_macro namespace="${namespace}" thruster_id="4"> <!-- lat back left-->
+   <origin xyz="-0.20506 0.20506 0" rpy="${0*d2r} ${0*d2r} ${45*d2r}"/>
+ </xacro:thruster_macro>
+ <xacro:thruster_macro namespace="${namespace}" thruster_id="5"> <!-- lat back right -->
+   <origin xyz="-0.20506 -0.20506 0" rpy="${0*d2r} ${0*d2r} ${-45*d2r}"/>
+ </xacro:thruster_macro>
+
+  <!-- <xacro:thruster_macro namespace="${namespace}" thruster_id="4">
+    <origin xyz="-0.192247 0.286933 0.0721539" rpy="${0*d2r} ${0*d2r} ${45*d2r}"/>
   </xacro:thruster_macro>
-  <xacro:thruster_macro namespace="${namespace}" thruster_id="5"> <!-- lat back right -->
-    <origin xyz="-0.20506 -0.20506 0" rpy="${0*d2r} ${0*d2r} ${-45*d2r}"/>
-  </xacro:thruster_macro>
+  <xacro:thruster_macro namespace="${namespace}" thruster_id="5">
+    <origin xyz="-0.192247 -0.286933 0.0721539" rpy="${0*d2r} ${0*d2r} ${-45*d2r}"/>
+  </xacro:thruster_macro> -->
 </robot>

--- a/simulator/descriptions/vortex_descriptions/launch/robosub_world.launch
+++ b/simulator/descriptions/vortex_descriptions/launch/robosub_world.launch
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
 
-<!-- 
+<!--
      Base code written by Kristoffer Rakstad Solberg, Student
      Copyright (c) 2019 Manta AUV, Vortex NTNU.
      All rights reserved. -->
 
 <launch>
     <arg name="gui" default="true"/>
-    <arg name="paused" default="false"/>
+    <arg name="paused" default="false"/> <!--default should be false for the robot to move-->
     <arg name="set_timeout" default="false"/>
     <arg name="timeout" default="0.0"/>
 
@@ -47,7 +47,7 @@
                     pose:
                         position: [0, -50, -10]
                 east:
-                    plane: [100, 0.1, 20]   
+                    plane: [100, 0.1, 20]
                     pose:
                         position: [0, 50, -10]
         </rosparam>

--- a/simulator/descriptions/vortex_descriptions/launch/robosub_world_sub.launch
+++ b/simulator/descriptions/vortex_descriptions/launch/robosub_world_sub.launch
@@ -1,12 +1,12 @@
 <?xml version="1.0" ?>
 
-<!-- 
+<!--
      Base code written by Kristoffer Rakstad Solberg, Student
      Copyright (c) 2019 Manta AUV, Vortex NTNU.
      All rights reserved. -->
 
 <launch>
-  <include file="$(find vortex_descriptions)/launch/robosub_world.launch"/>
+  <include file="$(find vortex_descriptions)/launch/robosub_world.launch" pass_all_args="true"/>
   <include file="$(find urab_sub_description)/launch/upload_urab_sub.launch"/>
-  <include file="$(find urab_sub_thruster_manager)/launch/thruster_manager.launch"/> 
+  <include file="$(find urab_sub_thruster_manager)/launch/thruster_manager.launch"/>
 </launch>

--- a/simulator/descriptions/vortex_descriptions/launch/robosub_world_sub.launch
+++ b/simulator/descriptions/vortex_descriptions/launch/robosub_world_sub.launch
@@ -7,6 +7,6 @@
 
 <launch>
   <include file="$(find vortex_descriptions)/launch/robosub_world.launch" pass_all_args="true"/>
-  <include file="$(find urab_sub_description)/launch/upload_urab_sub.launch"/>
+  <include file="$(find urab_sub_description)/launch/upload_urab_sub.launch" pass_all_args="true"/>
   <include file="$(find urab_sub_thruster_manager)/launch/thruster_manager.launch"/>
 </launch>

--- a/simulator/scripts/display_images.py
+++ b/simulator/scripts/display_images.py
@@ -1,0 +1,4 @@
+import numpy as np
+import cv2
+
+

--- a/simulator/scripts/display_images.py
+++ b/simulator/scripts/display_images.py
@@ -1,4 +1,0 @@
-import numpy as np
-import cv2
-
-

--- a/simulator/scripts/read_cameras.py
+++ b/simulator/scripts/read_cameras.py
@@ -2,13 +2,9 @@ import rospy
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 
-class ImageListener():
+class ImageListener:
     """ Subscribes to ROS Image messages. Used for getting camera image data
     from the simulator and converting it for OpenCV. """
-
-    def __init__(self):
-        self.sub = rospy.Subscriber("/urab_sub/urab_sub/camerafront/camera_image",
-            Image, self.callback)
 
     def callback(self, img_msg):
         bridge = CvBridge()
@@ -21,11 +17,35 @@ class ImageListener():
         rospy.sleep(time) # time is in seconds
         return self.images
 
+class FrontCameraListener(ImageListener):
+    """ Gets image data from the front camera. """
+    def __init__(self):
+        self.subscr = rospy.Subscriber("/urab_sub/urab_sub/camerafront/camera_image",
+            Image, self.callback)
+
+class UnderCameraListener(ImageListener):
+    """ Gets image data from the bottom camera. """
+    def __init__(self):
+        self.subscr = rospy.Subscriber("/urab_sub/urab_sub/cameraunder/camera_image",
+            Image, self.callback)
+
 if __name__ == '__main__':
     rospy.init_node('img_listener', anonymous=True)
-    listener = ImageListener()
-    imgs = listener.get_images(1.0)
+    front_listen = FrontCameraListener()
+    imgs = front_listen.get_images(1.0)
 
+    print "FRONT CAMERA"
+    print "ImageListener.get_images() has type " + str(type(imgs))
+    print "Length of image list: " + str(len(imgs))
+    print "The first image has type " + str(type(imgs[0]))
+    print "The first image has dimensions " + str(imgs[0].shape)
+    print "Print out the first image:"
+    print imgs[0]
+
+    under_listen = UnderCameraListener()
+    imgs = under_listen.get_images(1.0)
+
+    print "\n\nBOTTOM CAMERA"
     print "ImageListener.get_images() has type " + str(type(imgs))
     print "Length of image list: " + str(len(imgs))
     print "The first image has type " + str(type(imgs[0]))

--- a/simulator/scripts/read_cameras.py
+++ b/simulator/scripts/read_cameras.py
@@ -12,6 +12,7 @@ class ImageListener():
 
     def callback(self, img_msg):
         bridge = CvBridge()
+        # Stores as a BGR array for OpenCV.
         cv_image = bridge.imgmsg_to_cv2(img_msg, desired_encoding='bgr8')
         self.images.append(cv_image)
 

--- a/simulator/scripts/read_cameras.py
+++ b/simulator/scripts/read_cameras.py
@@ -1,0 +1,33 @@
+import rospy
+from sensor_msgs.msg import Image
+from cv_bridge import CvBridge
+
+class ImageListener():
+    """ Subscribes to ROS Image messages. Used for getting camera image data
+    from the simulator and converting it for OpenCV. """
+
+    def __init__(self):
+        self.sub = rospy.Subscriber("/urab_sub/urab_sub/camerafront/camera_image",
+            Image, self.callback)
+
+    def callback(self, img_msg):
+        bridge = CvBridge()
+        cv_image = bridge.imgmsg_to_cv2(img_msg, desired_encoding='bgr8')
+        self.images.append(cv_image)
+
+    def get_images(self, time):
+        self.images = []
+        rospy.sleep(time) # time is in seconds
+        return self.images
+
+if __name__ == '__main__':
+    rospy.init_node('img_listener', anonymous=True)
+    listener = ImageListener()
+    imgs = listener.get_images(1.0)
+
+    print "ImageListener.get_images() has type " + str(type(imgs))
+    print "Length of image list: " + str(len(imgs))
+    print "The first image has type " + str(type(imgs[0]))
+    print "The first image has dimensions " + str(imgs[0].shape)
+    print "Print out the first image:"
+    print imgs[0]

--- a/simulator/scripts/read_cameras.py
+++ b/simulator/scripts/read_cameras.py
@@ -3,7 +3,7 @@ from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 
 class ImageListener:
-    """ Subscribes to ROS Image messages. Used for getting camera image data
+    """ Abstract class. Subscribes to ROS Image messages. Used for getting camera image data
     from the simulator and converting it for OpenCV. """
 
     def callback(self, img_msg):

--- a/simulator/scripts/read_cameras.py
+++ b/simulator/scripts/read_cameras.py
@@ -17,6 +17,11 @@ class ImageListener:
         rospy.sleep(time) # time is in seconds
         return self.images
 
+    def get_images_forever(self):
+        self.images = []
+        rospy.spin()
+        return self.images
+
 class FrontCameraListener(ImageListener):
     """ Gets image data from the front camera. """
     def __init__(self):
@@ -30,7 +35,9 @@ class UnderCameraListener(ImageListener):
             Image, self.callback)
 
 if __name__ == '__main__':
+    # not sure if this should be moved into the ImageListener class
     rospy.init_node('img_listener', anonymous=True)
+
     front_listen = FrontCameraListener()
     imgs = front_listen.get_images(1.0)
 

--- a/simulator/scripts/show_images.py
+++ b/simulator/scripts/show_images.py
@@ -9,7 +9,7 @@ def display_camera_images(listener, time, window_name="video"):
     imgs = listener.get_images(1.0)
     for frame in imgs:
         cv2.imshow(window_name, frame)
-         # you need to hold a key to see video progress, need to fix this
+         # you need to hold a key to see the video progress. Press q to quit.
         if cv2.waitKey(0) & 0xFF == ord('q'):
             break
     cv2.destroyAllWindows()

--- a/simulator/scripts/show_images.py
+++ b/simulator/scripts/show_images.py
@@ -1,0 +1,21 @@
+import rospy
+import numpy as np
+import cv2
+import read_cameras
+
+def display_camera_images(listener, time, window_name="video"):
+    """Displays camera images received from an ImageListener object, which
+    gets video data for the specified amount of time, in seconds."""
+    imgs = listener.get_images(1.0)
+    for frame in imgs:
+        cv2.imshow(window_name, frame)
+         # you need to hold a key to see video progress, need to fix this
+        if cv2.waitKey(0) & 0xFF == ord('q'):
+            break
+    cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    rospy.init_node('img_listener', anonymous=True)
+    front_listen = read_cameras.FrontCameraListener()
+    display_camera_images(front_listen, 1, "front camera")


### PR DESCRIPTION
Can run show_images.py script to show the images generated from the simulator.
To run gazebo headless is `roslaunch vortex_descriptions robosub_world_sub.launch gui:=false camerafront:=0 cameraunder:=false`.