### PR TITLE
Removed razor_imu from master repos for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ qtcreator-*
 
 # Catkin custom files
 CATKIN_IGNORE
-
 cmake-build-debug
+
+# IDE files
 .idea
+.vscode 

--- a/repos/deps.repos
+++ b/repos/deps.repos
@@ -3,7 +3,4 @@ repositories:
     type: git
     url: https://github.com/Liquid-ai/Plankton.git
     version: master
-  deps/razor_imu:
-    type: git
-    url: https://github.com/berkeleyauv/razor_imu_9dof.git
-    version: ros2
+

--- a/repos/deps_release.repos
+++ b/repos/deps_release.repos
@@ -3,7 +3,4 @@ repositories:
     type: git
     url: https://github.com/Liquid-ai/Plankton.git
     version: master
-  deps/razor_imu:
-    type: git
-    url: https://github.com/berkeleyauv/razor_imu_9dof.git
-    version: ros2
+


### PR DESCRIPTION
To make sure that the repo is buildable, we should remove the RazorIMU package from the dependencies. Also, we will maybe even migrate to a new IMU.